### PR TITLE
Feature/sync elastic with mysql (read database)

### DIFF
--- a/messenger-command/src/main/java/com/example/messengercommand/mysql/handler/MySqlMessageCommandHandler.java
+++ b/messenger-command/src/main/java/com/example/messengercommand/mysql/handler/MySqlMessageCommandHandler.java
@@ -1,11 +1,16 @@
 package com.example.messengercommand.mysql.handler;
 
+import com.example.messengercommand.mysql.sync.SyncCommandProducer;
+import com.example.messengerutilities.utility.DataTypes;
 import com.example.messengerutilities.utility.RequestTypes;
 import com.example.messengercommand.model.Message;
 import com.example.messengercommand.mysql.repository.MessageRepositoryMySql;
+import com.example.messengerutilities.utility.SyncEventType;
+import com.example.messengerutilities.utility.TopicNames;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
+import java.util.Map;
 import java.util.Optional;
 
 @Service
@@ -13,6 +18,7 @@ import java.util.Optional;
 public class MySqlMessageCommandHandler implements MySqlCommandHandler<Message> {
 
     private final MessageRepositoryMySql messageRepositoryMySql;
+    private final SyncCommandProducer syncCommandProducer;
 
     @Override
     public void handle(RequestTypes requestType, Message message) {
@@ -26,10 +32,12 @@ public class MySqlMessageCommandHandler implements MySqlCommandHandler<Message> 
 
     private void saveMessage(Message message) {
         messageRepositoryMySql.save(message);
+        syncCommandProducer.sendSyncEvent(TopicNames.MESSAGE_SYNC_TOPIC, SyncEventType.INSERT, Map.of(DataTypes.MESSAGE, message.getId()));
     }
 
     private void deleteMessage(Message message) {
         messageRepositoryMySql.delete(message);
+        syncCommandProducer.sendSyncEvent(TopicNames.MESSAGE_SYNC_TOPIC, SyncEventType.DELETE, Map.of(DataTypes.MESSAGE, message.getId()));
     }
 
     private void updateMessage(Message message) {
@@ -40,5 +48,6 @@ public class MySqlMessageCommandHandler implements MySqlCommandHandler<Message> 
             throw new RuntimeException("Message not found");
         }
         messageRepositoryMySql.save(message);
+        syncCommandProducer.sendSyncEvent(TopicNames.MESSAGE_SYNC_TOPIC, SyncEventType.UPDATE, Map.of(DataTypes.MESSAGE, message.getId()));
     }
 }

--- a/messenger-command/src/main/java/com/example/messengercommand/mysql/handler/MySqlUserCommandHandler.java
+++ b/messenger-command/src/main/java/com/example/messengercommand/mysql/handler/MySqlUserCommandHandler.java
@@ -1,11 +1,16 @@
 package com.example.messengercommand.mysql.handler;
 
+import com.example.messengercommand.mysql.sync.SyncCommandProducer;
+import com.example.messengerutilities.utility.DataTypes;
 import com.example.messengerutilities.utility.RequestTypes;
 import com.example.messengercommand.model.User;
 import com.example.messengercommand.mysql.repository.UserRepositoryMySql;
+import com.example.messengerutilities.utility.SyncEventType;
+import com.example.messengerutilities.utility.TopicNames;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
+import java.util.Map;
 import java.util.Optional;
 
 @Service
@@ -13,6 +18,7 @@ import java.util.Optional;
 public class MySqlUserCommandHandler implements MySqlCommandHandler<User> {
 
     private final UserRepositoryMySql userRepositoryMySql;
+    private final SyncCommandProducer syncCommandProducer;
 
     @Override
     public void handle(RequestTypes requestType, User user) {
@@ -25,10 +31,14 @@ public class MySqlUserCommandHandler implements MySqlCommandHandler<User> {
 
     private void saveUser(User user) {
         userRepositoryMySql.save(user);
+
+        Map<DataTypes, String> map = Map.of(DataTypes.USER, user.getId());
+        syncCommandProducer.sendSyncEvent(TopicNames.USER_SYNC_TOPIC, SyncEventType.INSERT, Map.of(DataTypes.USER, user.getId()));
     }
 
     private void deleteUser(User user) {
         userRepositoryMySql.delete(user);
+        syncCommandProducer.sendSyncEvent(TopicNames.USER_SYNC_TOPIC, SyncEventType.DELETE, Map.of(DataTypes.USER, user.getId()));
     }
 
     private void updateUser(User user) {
@@ -39,6 +49,7 @@ public class MySqlUserCommandHandler implements MySqlCommandHandler<User> {
             throw new RuntimeException("User not found");
         }
         userRepositoryMySql.save(user);
+        syncCommandProducer.sendSyncEvent(TopicNames.USER_SYNC_TOPIC, SyncEventType.UPDATE, Map.of(DataTypes.USER, user.getId()));
     }
 
 }

--- a/messenger-command/src/main/java/com/example/messengercommand/mysql/sync/SyncCommandProducer.java
+++ b/messenger-command/src/main/java/com/example/messengercommand/mysql/sync/SyncCommandProducer.java
@@ -1,0 +1,40 @@
+package com.example.messengercommand.mysql.sync;
+
+
+import com.example.messengerutilities.model.SyncEventTemplate;
+import com.example.messengerutilities.utility.DataTypes;
+import com.example.messengerutilities.utility.SyncEventType;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.support.SendResult;
+import org.springframework.stereotype.Component;
+
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class SyncCommandProducer {
+
+    private final KafkaTemplate<String, SyncEventTemplate> kafkaTemplate;
+
+    public void sendSyncEvent(String topic, SyncEventType type, Map<DataTypes, String> ids) {
+        final SyncEventTemplate syncEventTemplate = SyncEventTemplate
+                .builder()
+                .type(type)
+                .ids(ids)
+                .build();
+
+        CompletableFuture<SendResult<String, SyncEventTemplate>> future = kafkaTemplate.send(topic, syncEventTemplate);
+
+        future.whenComplete((result, exception) -> {
+            if (exception != null) {
+                log.error("Error while sending sync event", exception);
+                return;
+            }
+            log.info("Sync event sent to topic {}, result : {}", topic, result);
+        });
+    }
+}

--- a/messenger-command/src/main/java/com/example/messengercommand/mysql/sync/SyncProducerConfig.java
+++ b/messenger-command/src/main/java/com/example/messengercommand/mysql/sync/SyncProducerConfig.java
@@ -1,0 +1,32 @@
+package com.example.messengercommand.mysql.sync;
+
+import com.example.messengerutilities.model.SyncEventTemplate;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.kafka.core.DefaultKafkaProducerFactory;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.core.ProducerFactory;
+import org.springframework.kafka.support.serializer.JsonSerializer;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class SyncProducerConfig {
+
+    @Value(value = "${spring.kafka.bootstrap-servers}")
+    private String bootstrapAddress;
+
+    @Bean("syncKafkaFactory")
+    public ProducerFactory<String, SyncEventTemplate> producerFactory() {
+        Map<String, Object> props = new HashMap<>();
+        props.put(org.apache.kafka.clients.producer.ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapAddress);
+        props.put(org.apache.kafka.clients.producer.ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, JsonSerializer.class);
+        props.put(org.apache.kafka.clients.producer.ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, JsonSerializer.class);
+        return new DefaultKafkaProducerFactory<>(props);
+    }
+
+    @Bean("syncKafkaTemplate")
+    public KafkaTemplate<String, SyncEventTemplate> kafkaTemplate() {
+        return new KafkaTemplate<>(producerFactory());
+    }
+}

--- a/messenger-command/src/main/resources/application.properties
+++ b/messenger-command/src/main/resources/application.properties
@@ -4,9 +4,13 @@ server.port=8052
 
 ## kafka settings ##
 spring.kafka.bootstrap-servers = localhost:9092
+spring.kafka.producer.key-serializer=org.springframework.kafka.support.serializer.JsonSerializer
+spring.kafka.producer.value-serializer=org.springframework.kafka.support.serializer.JsonSerializer
+spring.kafka.producer.properties.spring.json.trusted.packages=com.example.messengerutilities.model
+spring.kafka.producer.properties.spring.json.value.default.type= com.example.messengerutilities.model.SyncEventTemplate
 spring.kafka.consumer.value-deserializer=org.springframework.kafka.support.serializer.JsonDeserializer
 spring.kafka.consumer.properties.spring.json.trusted.packages=com.example.messengerutilities.model
-spring.kafka.consumer.properties.spring.json.value.default.type: com.example.messengerutilities.model.KafkaDataStructure
+spring.kafka.consumer.properties.spring.json.value.default.type= com.example.messengerutilities.model.KafkaDataStructure
 
 
 ## mysql settings ##

--- a/messenger-query/pom.xml
+++ b/messenger-query/pom.xml
@@ -60,6 +60,10 @@
             <artifactId>elasticsearch-java</artifactId>
             <version>8.13.4</version>
         </dependency>
+        <dependency>
+            <groupId>org.springframework.kafka</groupId>
+            <artifactId>spring-kafka</artifactId>
+        </dependency>
 
         <!-- databases -->
 

--- a/messenger-query/src/main/java/com/example/messengerquery/Service/MessageQueryServiceImpl.java
+++ b/messenger-query/src/main/java/com/example/messengerquery/Service/MessageQueryServiceImpl.java
@@ -1,6 +1,6 @@
 package com.example.messengerquery.Service;
 
-import com.example.messengerquery.elasticsearch.index.Indexing;
+import com.example.messengerquery.elasticsearch.index.Indexer;
 import com.example.messengerquery.elasticsearch.repository.MessageElasticsearchRepository;
 import com.example.messengerquery.mapper.MessageMapper;
 import com.example.messengerquery.model.Message;
@@ -21,11 +21,11 @@ public class MessageQueryServiceImpl implements MessageQueryService {
 
     private final MessageElasticsearchRepository elasticsearchRepository;
     private final MessageRepository messageRepository;
-    private final Indexing<Message, MessageDocument> messageIndexing;
+    private final Indexer<Message, MessageDocument> messageIndexer;
 
     @PostConstruct
     private void init() {
-        messageIndexing.reindex();
+        messageIndexer.reindex();
     }
 
 

--- a/messenger-query/src/main/java/com/example/messengerquery/Service/SessionQueryServiceImpl.java
+++ b/messenger-query/src/main/java/com/example/messengerquery/Service/SessionQueryServiceImpl.java
@@ -1,6 +1,6 @@
 package com.example.messengerquery.Service;
 
-import com.example.messengerquery.elasticsearch.index.Indexing;
+import com.example.messengerquery.elasticsearch.index.Indexer;
 import com.example.messengerquery.elasticsearch.repository.SessionElasticsearchRepository;
 import com.example.messengerquery.mapper.SessionMapper;
 import com.example.messengerquery.model.Session;
@@ -21,11 +21,11 @@ public class SessionQueryServiceImpl implements SessionQueryService {
 
     private final SessionElasticsearchRepository elasticSearchRepository;
     private final SessionRepository sessionRepository;
-    private final Indexing<Session, SessionDocument> sessionIndexing;
+    private final Indexer<Session, SessionDocument> sessionIndexer;
 
     @PostConstruct
     private void init() {
-        sessionIndexing.reindex();
+        sessionIndexer.reindex();
     }
 
 

--- a/messenger-query/src/main/java/com/example/messengerquery/Service/UserQueryServiceImpl.java
+++ b/messenger-query/src/main/java/com/example/messengerquery/Service/UserQueryServiceImpl.java
@@ -1,6 +1,6 @@
 package com.example.messengerquery.Service;
 
-import com.example.messengerquery.elasticsearch.index.Indexing;
+import com.example.messengerquery.elasticsearch.index.Indexer;
 import com.example.messengerquery.elasticsearch.repository.UserElasticsearchRepository;
 import com.example.messengerquery.mapper.UserMapper;
 import com.example.messengerquery.model.User;
@@ -9,11 +9,9 @@ import com.example.messengerquery.mysql.repository.UserRepository;
 import jakarta.annotation.PostConstruct;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 
@@ -26,11 +24,11 @@ public class UserQueryServiceImpl implements UserQueryService {
 
     private final UserElasticsearchRepository elasticsearchRepository;
     private final UserRepository userRepository;
-    private final Indexing<User, UserDocument> userIndexing;
+    private final Indexer<User, UserDocument> userIndexer;
 
     @PostConstruct
     private void init() {
-        userIndexing.reindex();
+        userIndexer.reindex();
     }
 
 

--- a/messenger-query/src/main/java/com/example/messengerquery/elasticsearch/consumer/ElasticSearchConsumer.java
+++ b/messenger-query/src/main/java/com/example/messengerquery/elasticsearch/consumer/ElasticSearchConsumer.java
@@ -1,0 +1,27 @@
+package com.example.messengerquery.elasticsearch.consumer;
+
+import com.example.messengerutilities.model.SyncEventTemplate;
+import com.example.messengerutilities.utility.TopicNames;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.kafka.annotation.EnableKafka;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@EnableKafka
+@Component
+@RequiredArgsConstructor
+public class ElasticSearchConsumer {
+
+    private final SyncEventDispatcher syncEventDispatcher;
+
+    @KafkaListener(topics = {
+            TopicNames.USER_SYNC_TOPIC,
+            TopicNames.SESSION_SYNC_TOPIC,
+            TopicNames.MESSAGE_SYNC_TOPIC
+    }, groupId = "elasticsearch")
+    public void consume(SyncEventTemplate syncEventTemplate) {
+        syncEventDispatcher.dispatch(syncEventTemplate);
+    }
+}

--- a/messenger-query/src/main/java/com/example/messengerquery/elasticsearch/consumer/SyncEventDispatcher.java
+++ b/messenger-query/src/main/java/com/example/messengerquery/elasticsearch/consumer/SyncEventDispatcher.java
@@ -1,0 +1,31 @@
+package com.example.messengerquery.elasticsearch.consumer;
+
+import com.example.messengerquery.elasticsearch.index.Indexer;
+import com.example.messengerquery.model.*;
+import com.example.messengerutilities.model.SyncEventTemplate;
+import com.example.messengerutilities.utility.DataTypes;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.util.Set;
+
+@Component
+@RequiredArgsConstructor
+public class SyncEventDispatcher {
+
+    private final Indexer<User, UserDocument> userIndexer;
+    private final Indexer<Session, SessionDocument> sessionIndexer;
+    private final Indexer<Message, MessageDocument> messageIndexer;
+
+    public void dispatch(SyncEventTemplate syncEventTemplate) {
+        Set<DataTypes> keys = syncEventTemplate.getIds().keySet();
+
+        keys.forEach(key -> {
+            switch (key) {
+                case USER -> userIndexer.sync(syncEventTemplate.getType(), syncEventTemplate.getIds().get(key));
+                case SESSION -> sessionIndexer.sync(syncEventTemplate.getType(), syncEventTemplate.getIds().get(key));
+                case MESSAGE -> messageIndexer.sync(syncEventTemplate.getType(), syncEventTemplate.getIds().get(key));
+            }
+        });
+    }
+}

--- a/messenger-query/src/main/java/com/example/messengerquery/elasticsearch/index/Indexer.java
+++ b/messenger-query/src/main/java/com/example/messengerquery/elasticsearch/index/Indexer.java
@@ -1,0 +1,10 @@
+package com.example.messengerquery.elasticsearch.index;
+
+import com.example.messengerutilities.utility.SyncEventType;
+
+public interface Indexer<S,T> {
+
+    void index();
+    void reindex();
+    void sync(SyncEventType type, String id);
+}

--- a/messenger-query/src/main/java/com/example/messengerquery/elasticsearch/index/Indexing.java
+++ b/messenger-query/src/main/java/com/example/messengerquery/elasticsearch/index/Indexing.java
@@ -1,7 +1,0 @@
-package com.example.messengerquery.elasticsearch.index;
-
-public interface Indexing<S,T> {
-
-    void index();
-    void reindex();
-}

--- a/messenger-query/src/main/java/com/example/messengerquery/mysql/repository/SessionRepository.java
+++ b/messenger-query/src/main/java/com/example/messengerquery/mysql/repository/SessionRepository.java
@@ -25,4 +25,7 @@ public interface SessionRepository extends JpaRepository<Session, String> {
     @EntityGraph(attributePaths = {"user1", "user2"})
     @Query(value = "select s from Session s")
     Page<Session> findAllEntityGraph(Pageable pageable);
+
+    @EntityGraph(attributePaths = {"user1", "user2"})
+    Optional<Session> findById(String id);
 }

--- a/messenger-query/src/main/resources/application.properties
+++ b/messenger-query/src/main/resources/application.properties
@@ -2,6 +2,12 @@ spring.application.name=messenger-query
 
 server.port=8051
 
+## kafka settings ##
+spring.kafka.bootstrap-servers = localhost:9092
+spring.kafka.consumer.value-deserializer=org.springframework.kafka.support.serializer.JsonDeserializer
+spring.kafka.consumer.properties.spring.json.trusted.packages=com.example.messengerutilities.model
+spring.kafka.consumer.properties.spring.json.value.default.type: com.example.messengerutilities.model.SyncEventTemplate
+
 # mysql settings 
 spring.datasource.url=jdbc:mysql://localhost:3306/messengerDevDb
 spring.datasource.driverClassName=com.mysql.cj.jdbc.Driver

--- a/messenger-utilities/src/main/java/com/example/messengerutilities/model/SyncEventTemplate.java
+++ b/messenger-utilities/src/main/java/com/example/messengerutilities/model/SyncEventTemplate.java
@@ -1,0 +1,21 @@
+package com.example.messengerutilities.model;
+
+import com.example.messengerutilities.utility.DataTypes;
+import com.example.messengerutilities.utility.SyncEventType;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import lombok.*;
+
+import java.util.Map;
+
+@Setter
+@Getter
+@ToString
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class SyncEventTemplate {
+
+    private SyncEventType type;
+    private Map<DataTypes, String> ids;
+}

--- a/messenger-utilities/src/main/java/com/example/messengerutilities/utility/SyncEventType.java
+++ b/messenger-utilities/src/main/java/com/example/messengerutilities/utility/SyncEventType.java
@@ -1,0 +1,7 @@
+package com.example.messengerutilities.utility;
+
+public enum SyncEventType {
+    INSERT,
+    UPDATE,
+    DELETE
+}

--- a/messenger-utilities/src/main/java/com/example/messengerutilities/utility/TopicNames.java
+++ b/messenger-utilities/src/main/java/com/example/messengerutilities/utility/TopicNames.java
@@ -4,13 +4,14 @@ public class TopicNames {
 
     public static final String USER_WRITE_TOPIC = "user-write-topic";
 
-    public static final String USER_READ_TOPIC = "user-read-topic";
+    public static final String USER_SYNC_TOPIC = "user-sync-topic";
 
     public static final String SESSION_WRITE_TOPIC = "session-write-topic";
 
-    public static final String SESSION_READ_TOPIC = "session-read-topic";
+    public static final String SESSION_SYNC_TOPIC = "session-sync-topic";
 
     public static final String MESSAGE_WRITE_TOPIC = "message-write-topic";
 
-    public static final String MESSAGE_READ_TOPIC = "message-read-topic";
+    public static final String MESSAGE_SYNC_TOPIC = "message-sync-topic";
+
 }


### PR DESCRIPTION
I have added a strategy to update **index** with read **database** . 
In `command` module **mysql** handlers (user , session and message) will produce sync event by write request (insert , update and delete) using its **producer** then `query` module using its **consumer** which is located in elastic search package will consume events using its dispatcher .